### PR TITLE
Fix Tailwind build warning

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,8 @@ module.exports = {
   content: [
     "./pages/**/*.{js,ts,jsx,tsx}",
     "./components/**/*.{js,ts,jsx,tsx}",
-    "./styles/**/*.{css}" // Add this line
+    // Include global stylesheets
+    "./styles/**/*.css",
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- clean up the Tailwind `content` glob so build runs without warnings

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a3894c6f8832cae5d5f8d35044b9f