### PR TITLE
Add site-wide banner

### DIFF
--- a/components/ConstructionBanner.js
+++ b/components/ConstructionBanner.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function ConstructionBanner() {
+  return (
+    <div className="bg-yellow-300 text-center py-2 text-sm font-semibold text-gray-800">
+      Site is under construction - will be ready soon
+    </div>
+  );
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,9 +1,11 @@
 import '../styles/globals.css';
 import AIAssistant from '../components/AIAssistant';
+import ConstructionBanner from '../components/ConstructionBanner';
 
 export default function App({ Component, pageProps }) {
   return (
     <>
+      <ConstructionBanner />
       <Component {...pageProps} />
       <AIAssistant />
     </>


### PR DESCRIPTION
## Summary
- add `ConstructionBanner` component
- render the banner for all pages in `_app.js`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a45c4b0f0832c914b36db26ca23f7