### PR TITLE
Add JSON-LD schema to pages

### DIFF
--- a/pages/declaration.js
+++ b/pages/declaration.js
@@ -2,11 +2,28 @@ import Head from 'next/head';
 import Navbar from '../components/Navbar';
 import Footer from '../components/Footer';
 
+const declarationSchema = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: "The Declaration of Harm | United for Accountability",
+  description:
+    "Read the Declaration of Harm that unites stories of injustice and calls for sweeping accountability across government and corporate systems.",
+  url: "https://www.unitedforaccountability.org/declaration",
+  author: {
+    "@type": "Organization",
+    name: "United for Accountability",
+  },
+};
+
 export default function Declaration() {
   return (
     <>
       <Head>
         <title>The Declaration of Harm | United for Accountability</title>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(declarationSchema) }}
+        />
       </Head>
       <Navbar />
       <main className="max-w-3xl mx-auto px-6 py-12">

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,21 @@ import Navbar from '../components/Navbar';
 import Footer from '../components/Footer';
 import Head from 'next/head';
 
+const homeSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "United for Accountability - Mass Tort Platform for Justice",
+  description:
+    "Join United for Accountability's grassroots campaign to document systemic harm and demand structural reform through coordinated mass tort litigation.",
+  url: "https://www.unitedforaccountability.org/",
+  publisher: {
+    "@type": "Organization",
+    name: "United for Accountability",
+    logo:
+      "https://www.unitedforaccountability.org/images/united-for-accountability-logo.png",
+  },
+};
+
 export default function Home() {
   return (
     <>
@@ -15,6 +30,10 @@ export default function Home() {
         <meta property="og:image" content="/public/og-image.jpg" />
         <link rel="canonical" href="https://www.unitedforaccountability.org/" />
         <meta name="google-site-verification" content="uIC3ruO2jzHCU2QSGLKdGYAg82jPZ4xuKU0IBmG_tbg" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(homeSchema) }}
+        />
       </Head>
       <Navbar />
       <main className="px-6 py-16 max-w-3xl mx-auto text-gray-800">

--- a/pages/pages_sign.js
+++ b/pages/pages_sign.js
@@ -7,6 +7,15 @@ import GuidedStoryHelper from '../components/GuidedStoryHelper';
 import DemographicForm from '../components/DemographicForm';
 import GuidedStoryAssistant from '../components/GuidedStoryAssistant';
 
+const signSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  name: "Sign the Declaration | United for Accountability",
+  description:
+    "Submit your story of harm and sign the United for Accountability Declaration to help build a powerful mass tort case.",
+  url: "https://www.unitedforaccountability.org/sign",
+};
+
 export default function Sign() {
   const [story, setStory] = useState('');
   const [submitted, setSubmitted] = useState(false);
@@ -30,6 +39,10 @@ export default function Sign() {
     <>
       <Head>
         <title>Sign the Declaration | United for Accountability</title>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(signSchema) }}
+        />
       </Head>
 
       <Navbar />

--- a/pages/sign.js
+++ b/pages/sign.js
@@ -5,6 +5,15 @@ import { useState } from 'react';
 import StoryAIHelper from '../components/StoryAIHelper';
 import GuidedStoryHelper from '../components/GuidedStoryHelper';
 
+const signSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  name: "Sign the Declaration | United for Accountability",
+  description:
+    "Share your story of harm and join the United for Accountability mass tort movement by signing the Declaration.",
+  url: "https://www.unitedforaccountability.org/sign",
+};
+
 export default function Sign() {
   const [story, setStory] = useState('');
   const [submitted, setSubmitted] = useState(false);
@@ -59,6 +68,10 @@ export default function Sign() {
     <>
       <Head>
         <title>Sign the Declaration | United for Accountability</title>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(signSchema) }}
+        />
       </Head>
 
       <Navbar />

--- a/pages/stories.js
+++ b/pages/stories.js
@@ -2,11 +2,24 @@ import Head from 'next/head';
 import Navbar from '../components/Navbar';
 import Footer from '../components/Footer';
 
+const storiesSchema = {
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  name: "Stories of Harm | United for Accountability",
+  description:
+    "Browse real stories submitted by people impacted by systemic injustice and learn why a united mass tort effort is needed.",
+  url: "https://www.unitedforaccountability.org/stories",
+};
+
 export default function Stories() {
   return (
     <>
       <Head>
         <title>Stories of Harm | United for Accountability</title>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(storiesSchema) }}
+        />
       </Head>
       <Navbar />
       <main className="max-w-2xl mx-auto px-6 py-12">


### PR DESCRIPTION
## Summary
- embed JSON-LD structured data on each page for better SEO

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a9c60cf00832c85a909e03ebbc98f