### PR TITLE
Add Open Graph tags

### DIFF
--- a/pages/declaration.js
+++ b/pages/declaration.js
@@ -20,6 +20,31 @@ export default function Declaration() {
     <>
       <Head>
         <title>The Declaration of Harm | United for Accountability</title>
+        <meta
+          name="description"
+          content="Read the Declaration of Harm that unites stories of injustice and calls for sweeping accountability across government and corporate systems."
+        />
+        <meta property="og:title" content="The Declaration of Harm" />
+        <meta
+          property="og:description"
+          content="Read the Declaration of Harm that unites stories of injustice and calls for sweeping accountability across government and corporate systems."
+        />
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content="https://www.unitedforaccountability.org/declaration" />
+        <meta
+          property="og:image"
+          content="https://www.unitedforaccountability.org/images/united-for-accountability-logo.png"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="The Declaration of Harm | United for Accountability" />
+        <meta
+          name="twitter:description"
+          content="Mass Tort | Civil Rights | Justice Movement"
+        />
+        <meta
+          name="twitter:image"
+          content="https://www.unitedforaccountability.org/images/united-for-accountability-logo.png"
+        />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(declarationSchema) }}

--- a/pages/index.js
+++ b/pages/index.js
@@ -27,7 +27,23 @@ export default function Home() {
         <meta property="og:description" content="Join the growing mass tort movement to expose injustice and demand restitution." />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://www.unitedforaccountability.org/" />
-        <meta property="og:image" content="/public/og-image.jpg" />
+        <meta
+          property="og:image"
+          content="https://www.unitedforaccountability.org/images/united-for-accountability-logo.png"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+          name="twitter:title"
+          content="United for Accountability | Mass Tort Platform for Justice"
+        />
+        <meta
+          name="twitter:description"
+          content="We the Harmed. We the Healers. We the Force for Change. Join the growing movement to restore constitutional protections and demand justice."
+        />
+        <meta
+          name="twitter:image"
+          content="https://www.unitedforaccountability.org/images/united-for-accountability-logo.png"
+        />
         <link rel="canonical" href="https://www.unitedforaccountability.org/" />
         <meta name="google-site-verification" content="uIC3ruO2jzHCU2QSGLKdGYAg82jPZ4xuKU0IBmG_tbg" />
         <script

--- a/pages/mass-tort-framework.js
+++ b/pages/mass-tort-framework.js
@@ -279,6 +279,20 @@ export default function MassTortFramework() {
         <meta property="og:description" content="Access the legal framework to expose systemic harm, special interest capture, and constitutional violations through a national mass tort." />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://www.unitedforaccountability.org/mass-tort-framework" />
+        <meta
+          property="og:image"
+          content="https://www.unitedforaccountability.org/images/united-for-accountability-logo.png"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Mass Tort Framework | United for Accountability" />
+        <meta
+          name="twitter:description"
+          content="Mass Tort | Civil Rights | Justice Movement"
+        />
+        <meta
+          name="twitter:image"
+          content="https://www.unitedforaccountability.org/images/united-for-accountability-logo.png"
+        />
         <link rel="canonical" href="https://www.unitedforaccountability.org/mass-tort-framework" />
         <script
           type="application/ld+json"

--- a/pages/pages_sign.js
+++ b/pages/pages_sign.js
@@ -39,6 +39,31 @@ export default function Sign() {
     <>
       <Head>
         <title>Sign the Declaration | United for Accountability</title>
+        <meta
+          name="description"
+          content="Submit your story of harm and sign the United for Accountability Declaration to help build a powerful mass tort case."
+        />
+        <meta property="og:title" content="Sign the Declaration" />
+        <meta
+          property="og:description"
+          content="Submit your story of harm and sign the Declaration to help build a powerful mass tort case."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://www.unitedforaccountability.org/sign" />
+        <meta
+          property="og:image"
+          content="https://www.unitedforaccountability.org/images/united-for-accountability-logo.png"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Sign the Declaration | United for Accountability" />
+        <meta
+          name="twitter:description"
+          content="Mass Tort | Civil Rights | Justice Movement"
+        />
+        <meta
+          name="twitter:image"
+          content="https://www.unitedforaccountability.org/images/united-for-accountability-logo.png"
+        />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(signSchema) }}

--- a/pages/sign.js
+++ b/pages/sign.js
@@ -68,6 +68,31 @@ export default function Sign() {
     <>
       <Head>
         <title>Sign the Declaration | United for Accountability</title>
+        <meta
+          name="description"
+          content="Share your story of harm and join the United for Accountability mass tort movement by signing the Declaration."
+        />
+        <meta property="og:title" content="Sign the Declaration" />
+        <meta
+          property="og:description"
+          content="Submit your story of harm and sign the Declaration to help build a powerful mass tort case."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://www.unitedforaccountability.org/sign" />
+        <meta
+          property="og:image"
+          content="https://www.unitedforaccountability.org/images/united-for-accountability-logo.png"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Sign the Declaration | United for Accountability" />
+        <meta
+          name="twitter:description"
+          content="Mass Tort | Civil Rights | Justice Movement"
+        />
+        <meta
+          name="twitter:image"
+          content="https://www.unitedforaccountability.org/images/united-for-accountability-logo.png"
+        />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(signSchema) }}

--- a/pages/stories.js
+++ b/pages/stories.js
@@ -16,6 +16,31 @@ export default function Stories() {
     <>
       <Head>
         <title>Stories of Harm | United for Accountability</title>
+        <meta
+          name="description"
+          content="Browse real stories submitted by people impacted by systemic injustice and learn why a united mass tort effort is needed."
+        />
+        <meta property="og:title" content="Stories of Harm" />
+        <meta
+          property="og:description"
+          content="Browse real stories submitted by people impacted by systemic injustice and learn why a united mass tort effort is needed."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://www.unitedforaccountability.org/stories" />
+        <meta
+          property="og:image"
+          content="https://www.unitedforaccountability.org/images/united-for-accountability-logo.png"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Stories of Harm | United for Accountability" />
+        <meta
+          name="twitter:description"
+          content="Mass Tort | Civil Rights | Justice Movement"
+        />
+        <meta
+          name="twitter:image"
+          content="https://www.unitedforaccountability.org/images/united-for-accountability-logo.png"
+        />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(storiesSchema) }}


### PR DESCRIPTION
## Summary
- add full Open Graph + Twitter cards across site pages
- fix default Open Graph image on home page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688aac7a774c832cb407852dee407acb