### PR TITLE
Fix cases page component imports

### DIFF
--- a/pages/cases/index.js
+++ b/pages/cases/index.js
@@ -1,6 +1,6 @@
 import Head from 'next/head'
-import Navbar from '../components/Navbar'
-import Footer from '../components/Footer'
+import Navbar from '../../components/Navbar'
+import Footer from '../../components/Footer'
 import Link from 'next/link'
 
 export default function Cases() {


### PR DESCRIPTION
## Summary
- fix relative import paths for Navbar and Footer on cases page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e2175fe5c832ca969baf8aa926f74