### PR TITLE
Add reCAPTCHA verification to declaration form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "next": "13.4.12",
         "openai": "^4.104.0",
         "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "react-google-recaptcha": "^3.1.0"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.14",
@@ -1950,6 +1951,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
@@ -2403,7 +2413,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2643,6 +2652,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
@@ -2700,6 +2720,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-async-script": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-async-script/-/react-async-script-1.2.0.tgz",
+      "integrity": "sha512-bCpkbm9JiAuMGhkqoAiC0lLkb40DJ0HOEJIku+9JDjxX3Rcs+ztEOG13wbrOskt3n2DTrjshhaQ/iay+SnGg5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.0",
+        "prop-types": "^15.5.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -2712,6 +2745,25 @@
       "peerDependencies": {
         "react": "^18.2.0"
       }
+    },
+    "node_modules/react-google-recaptcha": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-google-recaptcha/-/react-google-recaptcha-3.1.0.tgz",
+      "integrity": "sha512-cYW2/DWas8nEKZGD7SCu9BSuVz8iOcOLHChHyi7upUuVhkpkhYG/6N3KDiTQ3XAiZ2UAZkfvYKMfAHOzBOcGEg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.5.0",
+        "react-async-script": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "next": "13.4.12",
     "openai": "^4.104.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "react-google-recaptcha": "^3.1.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.14",

--- a/pages/api/submit.js
+++ b/pages/api/submit.js
@@ -1,5 +1,16 @@
 // pages/api/submit.js
 
+const verifyRecaptcha = async (token) => {
+  const res = await fetch(`https://www.google.com/recaptcha/api/siteverify`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: `secret=${process.env.RECAPTCHA_SECRET_KEY}&response=${token}`,
+  });
+
+  const data = await res.json();
+  return data.success && data.score >= 0.5;
+};
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method Not Allowed' });
@@ -19,7 +30,13 @@ export default async function handler(req, res) {
     consentToUse,
     canContact,
     contactMethod,
+    token,
   } = req.body;
+
+  const isHuman = await verifyRecaptcha(token);
+  if (!isHuman) {
+    return res.status(400).json({ error: 'Invalid reCAPTCHA token' });
+  }
 
   try {
     const airtableRes = await fetch(`https://api.airtable.com/v0/${process.env.AIRTABLE_BASE_ID}/${encodeURIComponent(process.env.AIRTABLE_TABLE_NAME)}`, {

--- a/pages/sign.js
+++ b/pages/sign.js
@@ -1,7 +1,8 @@
 import Head from 'next/head';
 import Navbar from '../components/Navbar';
 import Footer from '../components/Footer';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
+import ReCAPTCHA from "react-google-recaptcha";
 import StoryAIHelper from '../components/StoryAIHelper';
 import GuidedStoryHelper from '../components/GuidedStoryHelper';
 import { db } from '../lib/firebase';
@@ -20,6 +21,9 @@ export default function Sign() {
   const [story, setStory] = useState('');
   const [submitted, setSubmitted] = useState(false);
   const [mode, setMode] = useState(''); // '' | 'ai' | 'guided'
+
+  const recaptchaRef = useRef(null);
+  const [captchaToken, setCaptchaToken] = useState(null);
 
   const [formData, setFormData] = useState({
     name: '',
@@ -44,7 +48,11 @@ export default function Sign() {
     }));
   };
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const token = await recaptchaRef.current.executeAsync();
+    setCaptchaToken(token);
+
     if (!story.trim() || !formData.name || !formData.email) {
       alert('Please complete the story and required fields.');
       return;
@@ -53,6 +61,7 @@ export default function Sign() {
     const data = {
       ...formData,
       story,
+      recaptchaToken: token,
       timestamp: serverTimestamp(),
     };
 
@@ -147,7 +156,7 @@ export default function Sign() {
             </div>
 
             {/* RIGHT COLUMN: FORM */}
-            <div>
+            <form onSubmit={handleSubmit}>
               <h2 className="text-xl font-bold mb-4">📋 Your Information</h2>
 
               <div className="space-y-4">
@@ -213,14 +222,20 @@ export default function Sign() {
 
                 {story && (
                   <button
+                    type="submit"
                     className="mt-6 w-full bg-blue-700 text-white py-2 rounded hover:bg-blue-800 font-semibold"
-                    onClick={handleSubmit}
                   >
                     🖊 Submit My Story & Information
                   </button>
                 )}
               </div>
-            </div>
+              <ReCAPTCHA
+                ref={recaptchaRef}
+                sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY}
+                size="invisible"
+                onChange={(token) => setCaptchaToken(token)}
+              />
+            </form>
           </>
         )}
       </main>


### PR DESCRIPTION
## Summary
- install `react-google-recaptcha`
- add invisible reCAPTCHA to declaration sign form and send token with submission
- verify reCAPTCHA tokens on the submit API before saving data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e8a941d8c832c9e65ca32f2c0a5a4