### PR TITLE
Align Palestine declaration form with other case forms

### DIFF
--- a/pages/cases/we-recognize-palestine/declaration.js
+++ b/pages/cases/we-recognize-palestine/declaration.js
@@ -70,19 +70,69 @@ export default function DeclarationForm() {
             </div>
 
             <div>
-              <label htmlFor="location" className="block text-sm font-medium text-gray-700">City & Country *</label>
-              <input type="text" id="location" name="location" required placeholder="City, Country" onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm" />
+              <label htmlFor="phone" className="block text-sm font-medium text-gray-700">Phone Number (optional)</label>
+              <input type="tel" id="phone" name="phone" onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm" />
             </div>
 
             <div>
-              <label htmlFor="statement" className="block text-sm font-medium text-gray-700">Why are you signing this declaration?</label>
-              <textarea id="statement" name="statement" rows="4" onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm" placeholder="Your message of solidarity or legal concern..."></textarea>
+              <label htmlFor="location" className="block text-sm font-medium text-gray-700">City & State *</label>
+              <input type="text" id="location" name="location" required placeholder="City, State" onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm" />
+            </div>
+
+            <div>
+              <label htmlFor="address" className="block text-sm font-medium text-gray-700">Home Address (optional)</label>
+              <input type="text" id="address" name="address" placeholder="Street Address" onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm" />
+            </div>
+
+            <div>
+              <label htmlFor="race" className="block text-sm font-medium text-gray-700">Race / Ethnicity (optional)</label>
+              <input type="text" id="race" name="race" placeholder="e.g., Black, Latino, White, Asian, Indigenous..." onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm" />
+            </div>
+
+            <div>
+              <label htmlFor="gender" className="block text-sm font-medium text-gray-700">Gender Identity (optional)</label>
+              <input type="text" id="gender" name="gender" onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm" />
+            </div>
+
+            <div>
+              <label htmlFor="age" className="block text-sm font-medium text-gray-700">Age Range (optional)</label>
+              <select id="age" name="age" onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm">
+                <option value="">Select...</option>
+                <option>Under 18</option>
+                <option>18–24</option>
+                <option>25–34</option>
+                <option>35–44</option>
+                <option>45–54</option>
+                <option>55–64</option>
+                <option>65+</option>
+              </select>
+            </div>
+
+            <div>
+              <label htmlFor="income" className="block text-sm font-medium text-gray-700">Income Bracket (optional)</label>
+              <input type="text" id="income" name="income" placeholder="e.g., $0–25k, $25–50k..." onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm" />
+            </div>
+
+            <div className="text-sm text-gray-600 bg-gray-100 p-4 rounded">
+              <strong>Why are we asking for this?</strong>
+              <ul className="list-disc ml-6 mt-1 text-gray-600 text-sm">
+                <li>Identify patterns of systemic harm (racial, regional, age-based, etc.)</li>
+                <li>Strengthen legal standing in federal civil rights claims</li>
+                <li>Contact you if your declaration becomes part of a formal filing</li>
+                <li>Ensure jurisdictional accuracy for where the harm occurred</li>
+              </ul>
+              <p className="mt-2">We will never sell or publish your information. All data is encrypted and used only for lawful public-interest litigation.</p>
+            </div>
+
+            <div>
+              <label htmlFor="statement" className="block text-sm font-medium text-gray-700">Why are you signing? (optional)</label>
+              <textarea id="statement" name="statement" rows="4" onChange={handleChange} className="mt-1 block w-full rounded-md border-gray-300 shadow-sm" placeholder="Your personal thoughts or message..."></textarea>
             </div>
 
             <div className="flex items-start">
               <input id="consent" name="consent" type="checkbox" required onChange={handleChange} className="h-4 w-4 text-green-600" />
               <label htmlFor="consent" className="ml-2 text-sm text-gray-700">
-                I affirm this is voluntary and may be used in legal filings or public record with my consent.
+                I affirm this is voluntary and may be used in a legal filing.
               </label>
             </div>
 


### PR DESCRIPTION
## Summary
- Extend the Palestine recognition declaration to include phone, address, demographic, and consent fields so its submission form matches other case pages.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898b70c2590832cbbdd140e09a093e4