### PR TITLE
feat: add representative signing support

### DIFF
--- a/components/SigningForSection.js
+++ b/components/SigningForSection.js
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+
+export default function SigningForSection({ formData, setFormData }) {
+  const [showAttestation, setShowAttestation] = useState(false);
+
+  const onChange = (e) => {
+    const { name, value, type, checked, files } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: files ? files[0] : (type === 'checkbox' ? checked : value),
+    }));
+  };
+
+  return (
+    <section className="space-y-4">
+      <h3 className="text-xl font-semibold">Who are you signing for?</h3>
+      <div className="space-y-2">
+        <label className="flex items-center gap-2">
+          <input type="radio" name="sign_for" value="self" checked={formData.sign_for === 'self'} onChange={onChange} required />
+          <span>Myself</span>
+        </label>
+        <label className="flex items-center gap-2">
+          <input type="radio" name="sign_for" value="minor" checked={formData.sign_for === 'minor'} onChange={onChange} />
+          <span>My minor child</span>
+        </label>
+        <label className="flex items-center gap-2">
+          <input type="radio" name="sign_for" value="incapacity" checked={formData.sign_for === 'incapacity'} onChange={onChange} />
+          <span>A loved one who cannot sign</span>
+        </label>
+      </div>
+
+      {formData.sign_for !== 'self' && (
+        <>
+          <div className="grid md:grid-cols-2 gap-4">
+            <div>
+              <h4 className="font-semibold mb-2">Your info</h4>
+              <input name="signer_fullName" placeholder="Your full name" className="w-full border p-2" required onChange={onChange} />
+              <input name="signer_email" placeholder="Your email" className="w-full border p-2 mt-2" required onChange={onChange} />
+              <input name="signer_phone" placeholder="Your phone (optional)" className="w-full border p-2 mt-2" onChange={onChange} />
+              <input name="relationship_to_person" placeholder="Relationship to person" className="w-full border p-2 mt-2" required onChange={onChange} />
+            </div>
+            <div>
+              <h4 className="font-semibold mb-2">Person you’re representing</h4>
+              <input name="rep_fullName" placeholder="Full name" className="w-full border p-2" required onChange={onChange} />
+              <input type="date" name="rep_dob" className="w-full border p-2 mt-2" required onChange={onChange} />
+              <div className="grid grid-cols-3 gap-2 mt-2">
+                <input name="rep_city" placeholder="City" className="border p-2" onChange={onChange} />
+                <input name="rep_state" placeholder="State" className="border p-2" onChange={onChange} />
+                <input name="rep_zip" placeholder="ZIP" className="border p-2" onChange={onChange} />
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-4">
+            <h4 className="font-semibold mb-2">Your legal authority</h4>
+            <select name="authority_type" className="border p-2 w-full" required onChange={(e) => {
+              onChange(e);
+              setShowAttestation(e.target.value === 'No formal document – next of kin attestation');
+            }}>
+              <option value="">Select authority</option>
+              {formData.sign_for === 'minor' ? (
+                <>
+                  <option>Parent</option>
+                  <option>Legal Guardian</option>
+                </>
+              ) : (
+                <>
+                  <option>Power of Attorney</option>
+                  <option>Court‑Appointed Conservator/Guardian</option>
+                  <option>Healthcare Proxy</option>
+                  <option>No formal document – next of kin attestation</option>
+                </>
+              )}
+            </select>
+
+            {showAttestation ? (
+              <label className="flex items-start gap-2 mt-2">
+                <input type="checkbox" name="authority_attestation" onChange={onChange} required />
+                <span>I attest under penalty of perjury that I am next of kin/primary caregiver and the individual cannot consent, and no legally superior representative is available.</span>
+              </label>
+            ) : (
+              <div className="mt-2">
+                <label className="block mb-1">Upload proof of authority (PDF/JPG/PNG)</label>
+                <input type="file" name="authority_file" accept=".pdf,.jpg,.jpeg,.png" onChange={onChange} />
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      <div className="mt-4">
+        <h4 className="font-semibold mb-2">Consent & Signature</h4>
+        <label className="flex items-start gap-2">
+          <input type="checkbox" name="consent_checked" required onChange={onChange} />
+          <span>
+            I agree to the <a href="/consent" target="_blank" className="underline">Consent & Use</a> terms and certify the information provided is true and correct.
+            {formData.sign_for !== 'self' && ' I certify I am authorized to sign on behalf of the named individual and will provide documentation upon request.'}
+          </span>
+        </label>
+        <input name="signature_name" placeholder="Type your full name as signature" className="w-full border p-2 mt-2" required onChange={onChange} />
+      </div>
+    </section>
+  );
+}

--- a/lib/firebase.js
+++ b/lib/firebase.js
@@ -1,5 +1,6 @@
 import { initializeApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
+import { getStorage } from "firebase/storage";
 
 // ✅ Firebase configuration
 const firebaseConfig = {
@@ -14,7 +15,8 @@ const firebaseConfig = {
 // 🧠 Initialize Firebase
 const app = initializeApp(firebaseConfig);
 
-// 🔥 Initialize Firestore
+// 🔥 Initialize Firestore & Storage
 const db = getFirestore(app);
+const storage = getStorage(app);
 
-export { db };
+export { app, db, storage };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@vercel/analytics": "^1.5.0",
         "firebase": "^12.0.0",
+        "formidable": "^3.5.4",
         "next": "13.4.12",
         "openai": "^4.104.0",
         "react": "18.2.0",
@@ -881,6 +882,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -917,6 +930,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1136,6 +1158,12 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
     "node_modules/asynckit": {
@@ -1520,6 +1548,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -1807,6 +1845,23 @@
       },
       "engines": {
         "node": ">= 12.20"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/fraction.js": {
@@ -2465,6 +2520,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/openai": {
@@ -3490,6 +3554,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@vercel/analytics": "^1.5.0",
     "firebase": "^12.0.0",
+    "formidable": "^3.5.4",
     "next": "13.4.12",
     "openai": "^4.104.0",
     "react": "18.2.0",

--- a/pages/api/submit.js
+++ b/pages/api/submit.js
@@ -1,6 +1,11 @@
+import formidable from 'formidable';
 import crypto from 'crypto';
-import { db } from '../../lib/firebase';
-import { collection, addDoc } from 'firebase/firestore';
+import { promises as fs } from 'fs';
+import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
+import { ref as storageRef, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { app, db, storage } from '../../lib/firebase';
+
+export const config = { api: { bodyParser: false } };
 
 const verifyRecaptcha = async (token) => {
   const res = await fetch('https://www.google.com/recaptcha/api/siteverify', {
@@ -12,106 +17,106 @@ const verifyRecaptcha = async (token) => {
   return data.success;
 };
 
-function canonicalizeForHash(payload) {
-  const signed = {
-    firstName: payload.firstName?.trim(),
-    lastName: payload.lastName?.trim(),
-    email: payload.email?.toLowerCase().trim(),
-    phone: payload.phone?.trim(),
-    state: payload.state,
-    county: payload.county,
-    standingType: payload.standingType,
-    harmCategory: (payload.harmCategory || []).sort(),
-    harmStatement: payload.harmStatement || '',
-    typedSignature: payload.typedSignature?.trim(),
-    perjuryDeclaration: !!payload.perjuryDeclaration,
-    eSignAcknowledgment: !!payload.eSignAcknowledgment,
-    consentToLegalUse: !!payload.consentToLegalUse,
-    clientSignedAt: payload.clientSignedAt,
-  };
-  return JSON.stringify(signed);
-}
-
-function sha256(input) {
-  return crypto.createHash('sha256').update(input, 'utf8').digest('hex');
-}
-
 export default async function handler(req, res) {
-  if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method Not Allowed' });
-  }
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method Not Allowed' });
 
-  const {
-    firstName,
-    lastName,
-    email,
-    phone,
-    addressLine1,
-    city,
-    state,
-    county,
-    zip,
-    standingType,
-    harmCategory,
-    harmStatement,
-    consentToLegalUse,
-    perjuryDeclaration,
-    eSignAcknowledgment,
-    typedSignature,
-    clientSignedAt,
-    token,
-  } = req.body;
+  const ip = (req.headers['x-forwarded-for'] || '').toString().split(',')[0] || req.socket.remoteAddress || '';
+  const ua = req.headers['user-agent'] || '';
 
-  const isHuman = await verifyRecaptcha(token);
-  if (!isHuman) {
-    return res.status(400).json({ error: 'Invalid reCAPTCHA token' });
-  }
+  const form = formidable({ multiples: false, maxFileSize: 10 * 1024 * 1024 });
+  form.parse(req, async (err, fields, files) => {
+    if (err) return res.status(400).json({ error: 'Invalid form data' });
+    try {
+      const fd = (k) => (fields[k]?.[0] ?? '').toString().trim();
 
-  if (!firstName || !lastName || !email || !phone || !state || !county || !typedSignature || !consentToLegalUse || !perjuryDeclaration || !eSignAcknowledgment) {
-    return res.status(400).json({ error: 'Missing required fields' });
-  }
-  if (standingType === 'direct-harm' && !harmStatement) {
-    return res.status(400).json({ error: 'Harm statement required for direct harm' });
-  }
+      const token = fd('token');
+      const isHuman = await verifyRecaptcha(token);
+      if (!isHuman) return res.status(400).json({ error: 'Invalid reCAPTCHA token' });
 
-  const canonical = canonicalizeForHash(req.body);
-  const submissionHash = sha256(canonical);
-  const now = new Date().toISOString();
-  const ip =
-    req.headers['x-forwarded-for']?.toString().split(',')[0].trim() ||
-    req.socket?.remoteAddress ||
-    'unknown';
-  const userAgent = req.headers['user-agent'] || 'unknown';
+      const sign_for = fd('sign_for') || 'self';
+      const consent_checked = fd('consent_checked') === 'on' || fd('consent_checked') === 'true';
+      const signature_name = fd('signature_name');
+      const clientSignedAt = fd('clientSignedAt');
+      const harmStatement = fd('harmStatement');
+      const harmCategory = fd('harmCategory') ? JSON.parse(fd('harmCategory')) : [];
 
-  try {
-    await addDoc(collection(db, 'Declarations'), {
-      firstName,
-      lastName,
-      email,
-      phone,
-      addressLine1,
-      city,
-      state,
-      county,
-      zip,
-      standingType,
-      harmCategory: harmCategory || [],
-      harmStatement: harmStatement || '',
-      consentToLegalUse: !!consentToLegalUse,
-      perjuryDeclaration: !!perjuryDeclaration,
-      eSignAcknowledgment: !!eSignAcknowledgment,
-      typedSignature,
-      clientSignedAt,
-      serverReceivedAt: now,
-      serverTimezone: 'UTC',
-      ipAddress: ip,
-      userAgent,
-      submissionHash,
-      version: 2,
-    });
-    res.status(200).json({ success: true, submissionHash });
-  } catch (error) {
-    console.error('Submission error:', error);
-    res.status(500).json({ error: 'Internal Server Error' });
-  }
+      if (!consent_checked || !signature_name) return res.status(400).json({ error: 'Consent and signature are required.' });
+
+      // Validation for authority
+      let authority_file_url = null;
+      const authority_type = fd('authority_type');
+      const isMinor = sign_for === 'minor';
+      const isIncapacity = sign_for === 'incapacity';
+
+      if (sign_for !== 'self') {
+        if (!authority_type) return res.status(400).json({ error: 'Authority type required.' });
+
+        const needsFile =
+          (isMinor && authority_type === 'Legal Guardian') ||
+          (isIncapacity && ['Power of Attorney', 'Court‑Appointed Conservator/Guardian', 'Healthcare Proxy'].includes(authority_type));
+
+        const attestation = authority_type === 'No formal document – next of kin attestation';
+
+        if (needsFile) {
+          const f = files['authority_file'];
+          if (!f) return res.status(400).json({ error: 'Proof of authority file required.' });
+          const file = f[0];
+          const buffer = await fs.readFile(file.filepath);
+          const path = `authority/${Date.now()}-${file.originalFilename}`;
+          await uploadBytes(storageRef(storage, path), buffer, { contentType: file.mimetype });
+          authority_file_url = await getDownloadURL(storageRef(storage, path));
+        } else if (attestation) {
+          if (!(fd('authority_attestation') === 'on' || fd('authority_attestation') === 'true')) {
+            return res.status(400).json({ error: 'Attestation checkbox required.' });
+          }
+        }
+      }
+
+      const signature_date = new Date().toISOString();
+      const signature_hash = crypto.createHash('sha256').update(`${signature_name}|${signature_date}|${ip}`).digest('hex');
+
+      await addDoc(collection(db, 'Declarations'), {
+        firstName: fd('firstName'),
+        lastName: fd('lastName'),
+        email: fd('email'),
+        phone: fd('phone'),
+        addressLine1: fd('addressLine1'),
+        city: fd('city'),
+        state: fd('state'),
+        county: fd('county'),
+        zip: fd('zip'),
+        standingType: fd('standingType'),
+        harmCategory,
+        harmStatement: harmStatement || '',
+        sign_for,
+        signer_fullName: fd('signer_fullName'),
+        signer_email: fd('signer_email'),
+        signer_phone: fd('signer_phone'),
+        relationship_to_person: fd('relationship_to_person'),
+        rep_fullName: fd('rep_fullName'),
+        rep_dob: fd('rep_dob'),
+        rep_city: fd('rep_city'),
+        rep_state: fd('rep_state'),
+        rep_zip: fd('rep_zip'),
+        authority_type,
+        authority_file_url,
+        authority_attestation: fd('authority_attestation') === 'on' || fd('authority_attestation') === 'true',
+        consent_checked,
+        consent_version: 'v1.3 – 2025-08-10',
+        signature_name,
+        signature_drawn_url: null,
+        signature_date,
+        signature_hash,
+        ip_address: ip,
+        user_agent: ua,
+        clientSignedAt,
+        created_at: serverTimestamp(),
+      });
+
+      res.status(200).json({ ok: true });
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: 'Server error' });
+    }
+  });
 }

--- a/pages/consent.js
+++ b/pages/consent.js
@@ -1,0 +1,28 @@
+import Head from 'next/head';
+import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
+
+const CONSENT_VERSION = 'v1.3 – 2025-08-10';
+
+export default function Consent() {
+  return (
+    <>
+      <Head>
+        <title>Consent & Use Terms</title>
+      </Head>
+      <Navbar />
+      <main className="max-w-3xl mx-auto px-6 py-12 space-y-4">
+        <h1 className="text-2xl font-bold">Consent &amp; Use Terms ({CONSENT_VERSION})</h1>
+        <p>
+          I agree to the Consent &amp; Use terms, authorize United for Accountability to store and use this submission for legal evaluation and potential litigation support, and certify that the information provided is true and correct.
+        </p>
+        <p>
+          When signing on behalf of someone else, I further certify I am authorized to sign on behalf of the named individual and, if requested, will provide documentation of my authority.
+        </p>
+      </main>
+      <Footer />
+    </>
+  );
+}
+
+export { CONSENT_VERSION };

--- a/pages/sign.js
+++ b/pages/sign.js
@@ -5,6 +5,7 @@ import { useRef, useState } from 'react';
 import ReCAPTCHA from "react-google-recaptcha";
 import StoryAIHelper from '../components/StoryAIHelper';
 import GuidedStoryHelper from '../components/GuidedStoryHelper';
+import SigningForSection from '../components/SigningForSection';
 // Submission handled via API route to ensure server-side validation
 
 const signSchema = {
@@ -43,10 +44,21 @@ export default function Sign() {
     zip: '',
     standingType: 'direct-harm',
     harmCategory: [],
-    consentToLegalUse: false,
-    perjuryDeclaration: false,
-    eSignAcknowledgment: false,
-    typedSignature: ''
+    sign_for: 'self',
+    signer_fullName: '',
+    signer_email: '',
+    signer_phone: '',
+    relationship_to_person: '',
+    rep_fullName: '',
+    rep_dob: '',
+    rep_city: '',
+    rep_state: '',
+    rep_zip: '',
+    authority_type: '',
+    authority_file: null,
+    authority_attestation: false,
+    consent_checked: false,
+    signature_name: ''
   });
 
   const handleChange = (e) => {
@@ -67,31 +79,70 @@ export default function Sign() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     const token = await recaptchaRef.current.executeAsync();
+    if (!formData.consent_checked || !formData.signature_name.trim()) {
+      alert('Consent and signature are required.');
+      return;
+    }
 
-    if (!formData.consentToLegalUse || !formData.perjuryDeclaration || !formData.eSignAcknowledgment) {
-      alert('All legal acknowledgments must be accepted.');
-      return;
-    }
-    if (!formData.typedSignature.trim()) {
-      alert('Typed signature is required.');
-      return;
-    }
     if (formData.standingType === 'direct-harm' && !harmStatement.trim()) {
       alert('Please describe your harm.');
       return;
     }
 
+    if (formData.sign_for === 'minor') {
+      if (!formData.rep_dob) {
+        alert('Date of birth required for the person represented.');
+        return;
+      }
+      const age = Math.floor((Date.now() - new Date(formData.rep_dob).getTime()) / (365.25 * 24 * 60 * 60 * 1000));
+      if (age >= 18) {
+        alert('Represented person must be under 18.');
+        return;
+      }
+      if (!['Parent', 'Legal Guardian'].includes(formData.authority_type)) {
+        alert('Invalid authority type for minor.');
+        return;
+      }
+      if (formData.authority_type === 'Legal Guardian' && !formData.authority_file) {
+        alert('Proof of authority is required for Legal Guardian.');
+        return;
+      }
+    }
+
+    if (formData.sign_for === 'incapacity') {
+      if (!formData.authority_type) {
+        alert('Authority type required.');
+        return;
+      }
+      const needsFile = ['Power of Attorney', 'Court‑Appointed Conservator/Guardian', 'Healthcare Proxy'].includes(formData.authority_type);
+      if (needsFile && !formData.authority_file) {
+        alert('Proof of authority file required.');
+        return;
+      }
+      if (formData.authority_type === 'No formal document – next of kin attestation' && !formData.authority_attestation) {
+        alert('Attestation checkbox required.');
+        return;
+      }
+    }
+
     const clientSignedAt = new Date().toISOString();
+    const fd = new FormData();
+    Object.entries(formData).forEach(([key, value]) => {
+      if (value !== null && value !== undefined) {
+        if (key === 'harmCategory') {
+          fd.append(key, JSON.stringify(value));
+        } else {
+          fd.append(key, value);
+        }
+      }
+    });
+    fd.append('harmStatement', harmStatement);
+    fd.append('clientSignedAt', clientSignedAt);
+    fd.append('token', token);
 
     const res = await fetch('/api/submit', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        ...formData,
-        harmStatement,
-        clientSignedAt,
-        token
-      })
+      body: fd,
     });
 
     if (res.ok) {
@@ -185,29 +236,34 @@ export default function Sign() {
 
             {/* RIGHT COLUMN: FORM */}
             <form onSubmit={handleSubmit}>
+              <SigningForSection formData={formData} setFormData={setFormData} />
               <h2 className="text-xl font-bold mb-4">📋 Your Information</h2>
 
               <div className="space-y-4">
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium mb-1">First Name *</label>
-                    <input name="firstName" value={formData.firstName} onChange={handleChange} required className="w-full border px-3 py-2 rounded" />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium mb-1">Last Name *</label>
-                    <input name="lastName" value={formData.lastName} onChange={handleChange} required className="w-full border px-3 py-2 rounded" />
-                  </div>
-                </div>
+                {formData.sign_for === 'self' && (
+                  <>
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <label className="block text-sm font-medium mb-1">First Name *</label>
+                        <input name="firstName" value={formData.firstName} onChange={handleChange} required className="w-full border px-3 py-2 rounded" />
+                      </div>
+                      <div>
+                        <label className="block text-sm font-medium mb-1">Last Name *</label>
+                        <input name="lastName" value={formData.lastName} onChange={handleChange} required className="w-full border px-3 py-2 rounded" />
+                      </div>
+                    </div>
 
-                <div>
-                  <label className="block text-sm font-medium mb-1">Email *</label>
-                  <input type="email" name="email" value={formData.email} onChange={handleChange} required className="w-full border px-3 py-2 rounded" />
-                </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Email *</label>
+                      <input type="email" name="email" value={formData.email} onChange={handleChange} required className="w-full border px-3 py-2 rounded" />
+                    </div>
 
-                <div>
-                  <label className="block text-sm font-medium mb-1">Phone *</label>
-                  <input name="phone" value={formData.phone} onChange={handleChange} required className="w-full border px-3 py-2 rounded" />
-                </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Phone *</label>
+                      <input name="phone" value={formData.phone} onChange={handleChange} required className="w-full border px-3 py-2 rounded" />
+                    </div>
+                  </>
+                )}
 
                 <div>
                   <label className="block text-sm font-medium mb-1">Address Line 1</label>
@@ -260,33 +316,6 @@ export default function Sign() {
                     <textarea name="harmStatement" value={harmStatement} onChange={(e) => setHarmStatement(e.target.value)} required className="w-full border px-3 py-2 rounded" />
                   </div>
                 )}
-
-                <p className="text-sm mt-6">
-                  <strong>Declaration:</strong> I declare under penalty of perjury that the foregoing is true and correct.
-                </p>
-                <p className="text-sm">
-                  <strong>Electronic Signature:</strong> I agree that my typed name below constitutes my electronic signature and has the same legal effect as a handwritten signature under the ESIGN Act.
-                </p>
-
-                <label className="block mt-2">
-                  <input type="checkbox" name="consentToLegalUse" checked={formData.consentToLegalUse} onChange={handleChange} required className="mr-2" />
-                  I consent to the use of this declaration for legal proceedings.
-                </label>
-                <label className="block">
-                  <input type="checkbox" name="perjuryDeclaration" checked={formData.perjuryDeclaration} onChange={handleChange} required className="mr-2" />
-                  I make this declaration under penalty of perjury.
-                </label>
-                <label className="block">
-                  <input type="checkbox" name="eSignAcknowledgment" checked={formData.eSignAcknowledgment} onChange={handleChange} required className="mr-2" />
-                  I agree this is my electronic signature.
-                </label>
-
-                <div className="mt-2">
-                  <label className="block text-sm font-medium mb-1">Type full legal name as signature *</label>
-                  <input name="typedSignature" value={formData.typedSignature} onChange={handleChange} required className="w-full border px-3 py-2 rounded" />
-                </div>
-
-                <input type="hidden" name="clientSignedAt" value={new Date().toISOString()} />
 
                 {harmStatement && (
                   <button type="submit" className="mt-6 w-full bg-blue-700 text-white py-2 rounded hover:bg-blue-800 font-semibold">


### PR DESCRIPTION
## Summary
- add signing for others with authority selection, file upload, and consent capture
- capture consent version and audit fields in API and Firestore
- expose consent & use terms page and firebase storage config

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6898b906ed14832c874850b99f1138da