### PR TITLE
Align reCAPTCHA key for Palestine declaration

### DIFF
--- a/pages/cases/we-recognize-palestine/declaration.js
+++ b/pages/cases/we-recognize-palestine/declaration.js
@@ -137,7 +137,7 @@ export default function DeclarationForm() {
             </div>
 
             <ReCAPTCHA
-              sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_KEY}
+              sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY}
               onChange={(token) => setCaptchaToken(token)}
               className="my-4"
             />


### PR DESCRIPTION
## Summary
- Use `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` for the We Recognize Palestine declaration form to match other form pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6898bc9c103c832ca9446ef7170d72e2