### PR TITLE
Handle missing reCAPTCHA key gracefully

### DIFF
--- a/pages/cases/corporate-congressional-influence-and-systemic-disenfranchisement/declaration.js
+++ b/pages/cases/corporate-congressional-influence-and-systemic-disenfranchisement/declaration.js
@@ -136,11 +136,17 @@ export default function DeclarationForm() {
               </label>
             </div>
 
-            <ReCAPTCHA
-              sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_KEY}
-              onChange={(token) => setCaptchaToken(token)}
-              className="my-4"
-            />
+            {process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY ? (
+              <ReCAPTCHA
+                sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY}
+                onChange={(token) => setCaptchaToken(token)}
+                className="my-4"
+              />
+            ) : (
+              <p className="text-red-600">
+                reCAPTCHA key missing. Form submission disabled.
+              </p>
+            )}
             <button type="submit" className="w-full bg-blue-900 text-white py-2 px-4 rounded hover:bg-blue-950">
               \u2705 Submit My Declaration
             </button>

--- a/pages/cases/unauthorized-rule/declaration.js
+++ b/pages/cases/unauthorized-rule/declaration.js
@@ -136,11 +136,17 @@ export default function DeclarationForm() {
               </label>
             </div>
 
-            <ReCAPTCHA
-              sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_KEY}
-              onChange={(token) => setCaptchaToken(token)}
-              className="my-4"
-            />
+            {process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY ? (
+              <ReCAPTCHA
+                sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY}
+                onChange={(token) => setCaptchaToken(token)}
+                className="my-4"
+              />
+            ) : (
+              <p className="text-red-600">
+                reCAPTCHA key missing. Form submission disabled.
+              </p>
+            )}
             <button type="submit" className="w-full bg-red-600 text-white py-2 px-4 rounded hover:bg-red-700">
               ✅ Submit My Declaration
             </button>

--- a/pages/cases/we-recognize-palestine/declaration.js
+++ b/pages/cases/we-recognize-palestine/declaration.js
@@ -136,11 +136,17 @@ export default function DeclarationForm() {
               </label>
             </div>
 
-            <ReCAPTCHA
-              sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY}
-              onChange={(token) => setCaptchaToken(token)}
-              className="my-4"
-            />
+            {process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY ? (
+              <ReCAPTCHA
+                sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY}
+                onChange={(token) => setCaptchaToken(token)}
+                className="my-4"
+              />
+            ) : (
+              <p className="text-red-600">
+                reCAPTCHA key missing. Form submission disabled.
+              </p>
+            )}
             <button type="submit" className="w-full bg-green-700 text-white py-2 px-4 rounded hover:bg-green-800">
               ✅ Submit My Declaration
             </button>

--- a/pages/sign.js
+++ b/pages/sign.js
@@ -23,6 +23,7 @@ export default function Sign() {
   const [mode, setMode] = useState(''); // '' | 'ai' | 'guided'
 
   const recaptchaRef = useRef(null);
+  const recaptchaKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
 
   const harmCategories = [
     'housing',
@@ -78,7 +79,15 @@ export default function Sign() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const token = await recaptchaRef.current.executeAsync();
+    if (!recaptchaKey) {
+      alert('reCAPTCHA key not configured.');
+      return;
+    }
+    const token = await recaptchaRef.current?.executeAsync();
+    if (!token) {
+      alert('reCAPTCHA failed. Please try again.');
+      return;
+    }
     if (!formData.consent_checked || !formData.signature_name.trim()) {
       alert('Consent and signature are required.');
       return;
@@ -323,7 +332,9 @@ export default function Sign() {
                   </button>
                 )}
               </div>
-              <ReCAPTCHA ref={recaptchaRef} sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY} size="invisible" />
+              {recaptchaKey && (
+                <ReCAPTCHA ref={recaptchaRef} sitekey={recaptchaKey} size="invisible" />
+              )}
             </form>
           </>
         )}


### PR DESCRIPTION
## Summary
- Wrap all ReCAPTCHA widgets in conditional rendering
- Show a warning when the public reCAPTCHA key is missing
- Guard sign form submission when the ReCAPTCHA token isn't available

## Testing
- `CI=1 npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6898c097e730832c801addbec48f78e3