### PR TITLE
Clarify missing reCAPTCHA site key warning

### DIFF
--- a/pages/cases/corporate-congressional-influence-and-systemic-disenfranchisement/declaration.js
+++ b/pages/cases/corporate-congressional-influence-and-systemic-disenfranchisement/declaration.js
@@ -144,7 +144,7 @@ export default function DeclarationForm() {
               />
             ) : (
               <p className="text-red-600">
-                reCAPTCHA key missing. Form submission disabled.
+                reCAPTCHA site key missing. Form submission disabled.
               </p>
             )}
             <button type="submit" className="w-full bg-blue-900 text-white py-2 px-4 rounded hover:bg-blue-950">

--- a/pages/cases/unauthorized-rule/declaration.js
+++ b/pages/cases/unauthorized-rule/declaration.js
@@ -144,7 +144,7 @@ export default function DeclarationForm() {
               />
             ) : (
               <p className="text-red-600">
-                reCAPTCHA key missing. Form submission disabled.
+                reCAPTCHA site key missing. Form submission disabled.
               </p>
             )}
             <button type="submit" className="w-full bg-red-600 text-white py-2 px-4 rounded hover:bg-red-700">

--- a/pages/cases/we-recognize-palestine/declaration.js
+++ b/pages/cases/we-recognize-palestine/declaration.js
@@ -144,7 +144,7 @@ export default function DeclarationForm() {
               />
             ) : (
               <p className="text-red-600">
-                reCAPTCHA key missing. Form submission disabled.
+                reCAPTCHA site key missing. Form submission disabled.
               </p>
             )}
             <button type="submit" className="w-full bg-green-700 text-white py-2 px-4 rounded hover:bg-green-800">


### PR DESCRIPTION
## Summary
- Clarify warning message shown when `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` is not configured in case declaration forms.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6898c2f60474832c82d06f35ee44e7de